### PR TITLE
Option to name the root vue elements 

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -25,8 +25,8 @@ const store = createStore({
 /**
  * create vue instance function
  */
-const createVueApp = () => {
-  const app = createApp({})
+const createVueApp = name => {
+  const app = createApp({ name: name });
 
   /**
    * vue components
@@ -84,7 +84,11 @@ if (appElement) {
   createVueApp().mount(appElement)
 } else {
   const vueElements = document.querySelectorAll('[vue]')
-  if (vueElements) vueElements.forEach(el => createVueApp().mount(el))
+  if (vueElements) {
+    vueElements.forEach(el => {
+      createVueApp(el.dataset.name).mount(el);
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
If you have multiple vue instances, devtools shows these as app1, app2, app3 etc. This PR allows you to add a `data-name="someName"` attribute to the element with the `vue` attribute and the root element will take that name.  If no name is passed, it continues to show app1 etc.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch, _not_ the `main` branch

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Whilst I'm not using this theme directly, I've taken lots of inspiration from it for my work, thank you.  
